### PR TITLE
Initial sphinx setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/build/
 
 # PyBuilder
 .pybuilder/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,33 @@
+import sys
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'qbaf-py'
+copyright = '2022, José Ruiz Alarcón, Timotheus Kampik'
+author = 'José Ruiz Alarcón, Timotheus Kampik'
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+# --- Path for autodoc ---
+sys.path.append('../../')

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,12 @@
+.. qbaf-py documentation master file, created by
+   sphinx-quickstart on Fri Dec  2 20:07:06 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to QBAF-Py's documentation!
+===================================
+QBAF-Py is a library for drawing inferences from Quantitative Bipolar Argumentation Frameworks (QBAFs) and explaining them. The library is written in CPython (C with a Python API) to facilitate speed and efficiency.
+
+.. automodule:: qbaf
+   :members:
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def main():
     source_files = [os.path.join(module_folder, file) for file in os.listdir(module_folder)]
 
     setup(
-        name='qbaf-py',
+        name='QBAF-Py',
         python_requires='>=3.8',
         version='0.1.0',
         description='QBAF-Py is a package for argumentation-based reasoning of Quantitative Bipolar Argumentation Frameworks.',


### PR DESCRIPTION
I added an initial config/setup for documentation with Sphinx.
You can build it by navigating to the `doc` folder and running `make html`.

However, I still don't get the full function signatures.
We can also try to use some magic to embed the README file into the documentation.

Let's discuss tomorrow.