### PR TITLE
Fix gradient ctrb edge case

### DIFF
--- a/qbaf_ctrbs/gradient.py
+++ b/qbaf_ctrbs/gradient.py
@@ -31,6 +31,10 @@ def determine_gradient_ctrb(topic, contributor, qbaf, epsilon=1.4901161193847656
         return qbaf_changed.final_strength(topic)
     
     contributor_strength = qbaf.final_strength(contributor)
-    strength_epsilon = func(contributor_strength + epsilon, qbaf)
     strength_base = func(contributor_strength, qbaf)
-    return (strength_epsilon - strength_base) / epsilon
+    try:
+        strength_epsilon = func(contributor_strength + epsilon, qbaf)
+        return (strength_epsilon - strength_base) / epsilon
+    except ValueError:
+        strength_epsilon = func(contributor_strength - epsilon, qbaf)
+        return (strength_base - strength_epsilon) / epsilon

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -8,3 +8,12 @@ def test_gradient():
     supps = [('a', 'b'), ('a', 'c'), ('a', 'd'), ('d', 'e')]
     qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics='DFQuAD_model')
     assert round(determine_gradient_ctrb('e', 'a', qbaf), 7) == 0
+
+def test_gradient_edge_case():
+    args = ['a', 'b', 'c']
+    initial_strengths = [0.1, 1, 1]
+    atts = [('b', 'a'), ('c', 'a')]
+    supps = []
+    qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics="DFQuAD_model")
+    assert determine_gradient_ctrb('a', 'b', qbaf) == 0
+    assert determine_gradient_ctrb('a', 'c', qbaf) == 0


### PR DESCRIPTION
If determining gradient would imply moving out of the domain We would get a value error. Now, we catch the error and then determine the gradient "in the other direction" instead (and then adjust the final term accordingly).