### PR TITLE
Fix gradient top edge case

### DIFF
--- a/src/qbaf_functions.c
+++ b/src/qbaf_functions.c
@@ -144,7 +144,7 @@ double top(PyObject *attacker_strengths, PyObject *supporter_strengths)
     while ((item = PyIter_Next(iterator))) {    // PyIter_Next returns a new reference
         double strength = PyFloat_AsDouble(item);
         Py_DECREF(item);
-        if (strength == -1.0 && PyErr_Occurred()) {
+        if (strength > 1 || strength < -1 || (strength == -1.0 && PyErr_Occurred())) {
             Py_DECREF(iterator);
             return -1;
         }

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -17,3 +17,15 @@ def test_gradient_edge_case():
     qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics="DFQuAD_model")
     assert determine_gradient_ctrb('a', 'b', qbaf) == 0
     assert determine_gradient_ctrb('a', 'c', qbaf) == 0
+
+def test_gradient_top_edge_case():
+    # if two contributors with maximum strength (and only them) attack or support a topic argument,
+    # their contributions are expected to zero.
+    args = ['a', 'b', 'c']
+    initial_strengths = [0.1, 1, 1]
+    atts = [('b', 'a'), ('c', 'a')]
+    supps = []
+    qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics="EulerBasedTop_model")
+    assert determine_gradient_ctrb('a', 'c', qbaf) == 0
+    assert determine_gradient_ctrb('a', 'b', qbaf) == 0
+    


### PR DESCRIPTION
Adjust semantics behavior: top aggregation function must not accept initial strength not in [-1, 1]