### PR TITLE
Handle set in remove

### DIFF
--- a/qbaf_ctrbs/removal.py
+++ b/qbaf_ctrbs/removal.py
@@ -6,7 +6,7 @@ def determine_removal_ctrb(topic, contributors, qbaf):
 
     Args:
         topic (string): The topic argument
-        contributor (string or set): The contributing argument(s)
+        contributors (string or set): The contributing argument(s)
         qbaf (QBAFramework): The QBAF that contains topic and contributor
 
     Returns:

--- a/qbaf_ctrbs/removal.py
+++ b/qbaf_ctrbs/removal.py
@@ -1,23 +1,27 @@
 from qbaf_ctrbs.utils import restrict
 
-def determine_removal_ctrb(topic, contributor, qbaf):
+def determine_removal_ctrb(topic, contributors, qbaf):
     """Determines the removal contribution of a contributor
     to a topic argument.
 
     Args:
         topic (string): The topic argument
-        contributor (string): The contributing argument
+        contributor (string | set): The contributing argument(s)
         qbaf (QBAFramework): The QBAF that contains topic and contributor
 
     Returns:
         float: The contribution of the contributor to the topic
     """
-    if topic == contributor:
+    if topic in contributors:
         raise Exception (
             'An argument\'s removal contribution to itself cannot be determined.')
-    if not topic in qbaf.arguments or not contributor in qbaf.arguments:
-        raise Exception ('Topic and contributor must be in the QBAF.')
+    # Ensure topic and argument(s) are in QBAF.
+    if not all(item in qbaf.arguments for item in [topic, *contributors]):
+            raise Exception ('Topic and contributor must be in the QBAF.')
+    # Check if input is a set of arguments (type: set) or single argument (type: string).
+    if not isinstance(contributors, set):
+        contributors = {contributors}
     fs_with = qbaf.final_strengths[topic]
-    restriction = restrict(qbaf, qbaf.arguments - {contributor})
+    restriction = restrict(qbaf, qbaf.arguments - contributors)
     fs_without = restriction.final_strengths[topic]
-    return fs_with - fs_without 
+    return  fs_with - fs_without

--- a/qbaf_ctrbs/removal.py
+++ b/qbaf_ctrbs/removal.py
@@ -6,7 +6,7 @@ def determine_removal_ctrb(topic, contributors, qbaf):
 
     Args:
         topic (string): The topic argument
-        contributor (string | set): The contributing argument(s)
+        contributor (string or set): The contributing argument(s)
         qbaf (QBAFramework): The QBAF that contains topic and contributor
 
     Returns:

--- a/tests/test_removal.py
+++ b/tests/test_removal.py
@@ -2,14 +2,25 @@ from qbaf import QBAFramework
 from qbaf_ctrbs.removal import determine_removal_ctrb
 
 def test_removal():
-    args = ['a', 'b', 'c']
+    args = ['a', 'b', 'c', 'd']
     is_a = 2
     is_b = 1
     is_c = 1
-    initial_strengths = [is_a, is_b, is_c]
-    atts = [('b', 'a')]
+    is_d = 1
+    initial_strengths = [is_a, is_b, is_c, is_d]
+    atts = [('b', 'a'), ('a', 'd')]
     supps = [('c', 'b')]
     qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics='basic_model')
     assert determine_removal_ctrb('a', 'b', qbaf) == -2
     assert determine_removal_ctrb('a', 'c', qbaf) == -1
     assert determine_removal_ctrb('b', 'a', qbaf) == 0
+    assert determine_removal_ctrb('b', 'c', qbaf) == 1
+    assert determine_removal_ctrb('c', 'a', qbaf) == 0
+    assert determine_removal_ctrb('d', 'c', qbaf) == 1
+    assert determine_removal_ctrb('d', 'a', qbaf) == 0
+    
+    assert determine_removal_ctrb('c', {'a', 'b'}, qbaf) == 0
+    assert determine_removal_ctrb('a', {'b', 'c'}, qbaf) == -2
+    assert determine_removal_ctrb('b', {'c', 'a'}, qbaf) == 1
+    assert determine_removal_ctrb('d', {'c', 'b'}, qbaf) == 2
+    assert determine_removal_ctrb('d', {'c', 'b', 'a'}, qbaf) == 0


### PR DESCRIPTION
CODE
Added functionality to determine_removal_ctrb() to quantify the contribution of sets of arguments to the final strength of another argument.

determine_removal_ctrb() can now handle both a single contributor (single str) and a set of contributors (set of str).

DOCS
Updated docstring in determine_removal_ctrb() to reflect argument name change: contributor --> contributors, and to reflect that this argument can now be a string or a set with: (string or set).

TESTS
Extended the determine_removal_ctrb test by extending the QBAF used in the test case with an additional argument and more asserts.
The old and new asserts are passing. 