### PR TITLE
Handle set in shapley

### DIFF
--- a/qbaf_ctrbs/shapley.py
+++ b/qbaf_ctrbs/shapley.py
@@ -34,12 +34,6 @@ def determine_shapley_ctrb(topic, contributors, qbaf):
         qbaf_without = restrict(qbaf, [arg for arg in qbaf.arguments if arg in lsubset + [topic]])
         qbaf_with = restrict(qbaf, [arg for arg in qbaf.arguments if arg in lsubset + [topic, *contributors]])
         weight = (math.factorial(len(lsubset)) * math.factorial(len(qbaf.arguments)-1-len(lsubset)-len(contributors)))/math.factorial(len(qbaf.arguments)-1-len(contributors)+1)
-
-        print("------------------------------")
-        print(f"{lsubset} ({len(lsubset)})")
-        print(f"{str(math.factorial(len(lsubset)) * math.factorial(len(qbaf.arguments)-1-len(lsubset)-len(contributors)))}/{str(math.factorial(len(qbaf.arguments)-1-len(contributors)+1))} * {str((qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic]))}")
-        print("------------------------------")
-
         sub_ctrb = weight * (qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic])
         sub_ctrbs.append(sub_ctrb)
     return sum(sub_ctrbs)

--- a/qbaf_ctrbs/shapley.py
+++ b/qbaf_ctrbs/shapley.py
@@ -1,31 +1,45 @@
 import math
 from qbaf_ctrbs.utils import restrict, determine_powerset
 
-def determine_shapley_ctrb(topic, contributor, qbaf):
+def determine_shapley_ctrb(topic, contributors, qbaf):
     """Determines the shapley contribution of a contributor
-    to a topic argument.
+    or a set of contributors to a topic argument.
+    
+    .. note::
+        If a set of contributors is provided, its elements are treated 
+        as a single player in the calculation. For example, given three 
+        arguments {a}, {b}, and {c}, specifying {b, c} as a contributor 
+        results in two players: {a} and {b, c}.
 
     Args:
         topic (string): The topic argument
-        contributor (string): The contributing argument
+        contributors (string or set): The contributing argument(s)
         qbaf (QBAFramework): The QBAF that contains topic and contributor
 
     Returns:
         float: The contribution of the contributor to the topic
     """
-    if topic == contributor:
+    if topic in contributors:
         raise Exception (
             'An argument\'s shapley contribution to itself cannot be determined.')
-    if not topic in qbaf.arguments or not contributor in qbaf.arguments:
-        raise Exception ('Topic and contributor must be in the QBAF.')
+    if not all(item in qbaf.arguments for item in [topic, *contributors]):
+            raise Exception ('Topic and contributor must be in the QBAF.')
+    if not isinstance(contributors, set):
+        contributors = {contributors}
     sub_ctrbs = []
-    reduced_args = [arg for arg in qbaf.arguments if arg not in [contributor, topic]]
+    reduced_args = [arg for arg in qbaf.arguments if arg not in [*contributors, topic]]
     subsets = determine_powerset(reduced_args)
     for subset in subsets:
         lsubset = list(subset)
         qbaf_without = restrict(qbaf, [arg for arg in qbaf.arguments if arg in lsubset + [topic]])
-        qbaf_with = restrict(qbaf, [arg for arg in qbaf.arguments if arg in lsubset + [topic, contributor]])
-        weight = (math.factorial(len(lsubset)) * math.factorial(len(qbaf.arguments)-2-len(lsubset)))/math.factorial(len(qbaf.arguments)-1)
+        qbaf_with = restrict(qbaf, [arg for arg in qbaf.arguments if arg in lsubset + [topic, *contributors]])
+        weight = (math.factorial(len(lsubset)) * math.factorial(len(qbaf.arguments)-1-len(lsubset)-len(contributors)))/math.factorial(len(qbaf.arguments)-1-len(contributors)+1)
+
+        print("------------------------------")
+        print(f"{lsubset} ({len(lsubset)})")
+        print(f"{str(math.factorial(len(lsubset)) * math.factorial(len(qbaf.arguments)-1-len(lsubset)-len(contributors)))}/{str(math.factorial(len(qbaf.arguments)-1-len(contributors)+1))} * {str((qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic]))}")
+        print("------------------------------")
+
         sub_ctrb = weight * (qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic])
         sub_ctrbs.append(sub_ctrb)
     return sum(sub_ctrbs)

--- a/tests/test_shapley.py
+++ b/tests/test_shapley.py
@@ -13,3 +13,13 @@ def test_shapley():
     assert determine_shapley_ctrb('a', 'b', qbaf) == -1.5
     assert determine_shapley_ctrb('a', 'c', qbaf) == -0.5
     assert determine_shapley_ctrb('b', 'a', qbaf) == 0
+    assert determine_shapley_ctrb('c', {'a', 'b'}, qbaf) == 0
+    assert determine_shapley_ctrb('c', {'a', 'b'}, qbaf) == 0
+    assert determine_shapley_ctrb('b', {'c', 'a'}, qbaf) == 1
+    
+    # Disconnected null-player should have no effect.
+    args.append('d') # Add null-player (no atts & no supps).
+    initial_strengths.append(0) # Make initial strength of d 0.
+    qbaf_bigger = QBAFramework(args, initial_strengths, atts, supps, semantics='basic_model')
+    assert determine_shapley_ctrb('a', 'b', qbaf_bigger) == determine_shapley_ctrb('a', 'b', qbaf)
+    assert determine_shapley_ctrb('b', {'c', 'a'}, qbaf_bigger) == determine_shapley_ctrb('b', {'c', 'a'}, qbaf)


### PR DESCRIPTION
CODE
Added functionality to determine_shapley_ctrb() to quantify the contribution of a set of arguments to the final strength of another argument.

determine_shapley_ctrb() can now handle both a single contributor (single str) and a set of contributors (set of str).

DOCS
Updated docstring. Added a note to clarify the implementation and assumptions.
Here is a screenshot of what the generated docs looks like with the note: ![docs](https://github.com/user-attachments/assets/f8eb152d-0f96-4278-919e-1a2b4f366446)

TESTS
Extended the tests for determine_shapley_ctrb by including tests with a set of contributors and also verifying that adding a disconnected (no atts & no supps) null-player does not affect the result.
The old and new asserts are passing.