### PR TITLE
Handle set in iremove

### DIFF
--- a/qbaf_ctrbs/intrinsic_removal.py
+++ b/qbaf_ctrbs/intrinsic_removal.py
@@ -1,31 +1,33 @@
 from qbaf import QBAFramework
 from qbaf_ctrbs.utils import restrict
 
-def determine_iremoval_ctrb(topic, contributor, qbaf):
+def determine_iremoval_ctrb(topic, contributors, qbaf):
     """Determines the intrinsic removal contribution of a contributor
-    to a topic argument.
+     or a set of contributors to a topic argument.
 
     Args:
         topic (string): The topic argument
-        contributor (string): The contributing argument
+        contributors (string or set): The contributing argument(s)
         qbaf (QBAFramework): The QBAF that contains topic and contributor
 
     Returns:
         float: The contribution of the contributor to the topic
     """
-    if topic == contributor:
+    if topic in contributors:
         raise Exception (
             'An argument\'s intrinsic removal contribution to itself cannot be determined.')
-    if not topic in qbaf.arguments or not contributor in qbaf.arguments:
+    if not all(item in qbaf.arguments for item in [topic, *contributors]):
         raise Exception ('Topic and contributor must be in the QBAF.')
-    attackers = [(source, target) for source, target in qbaf.attack_relations.relations if not target == contributor]
-    supporters = [(source, target) for source, target in qbaf.support_relations.relations if not target == contributor]
+    if not isinstance(contributors, set):
+        contributors = {contributors}
+    attackers = [(source, target) for source, target in qbaf.attack_relations.relations if (source in contributors or target not in contributors)]
+    supporters = [(source, target) for source, target in qbaf.support_relations.relations if (source in contributors or target not in contributors)]
     arguments = list(qbaf.arguments)
     initial_strengths = [qbaf.initial_strengths[argument] for argument in arguments]
     qbaf_with = QBAFramework(arguments, initial_strengths,
                             attackers, supporters,
                             semantics=qbaf.semantics)
-    qbaf_without = restrict(qbaf_with, qbaf.arguments - {contributor})
+    qbaf_without = restrict(qbaf_with, qbaf.arguments - contributors)
     fs_with = qbaf_with.final_strengths[topic]
     fs_without = qbaf_without.final_strengths[topic]
     return fs_with - fs_without

--- a/tests/test_iremoval.py
+++ b/tests/test_iremoval.py
@@ -3,14 +3,17 @@ from qbaf import QBAFramework
 from qbaf_ctrbs.intrinsic_removal import determine_iremoval_ctrb
 
 def test_iremoval():
-    args = ['a', 'b', 'c']
+    args = ['a', 'b', 'c', 'd']
     is_a = 2
     is_b = 1
     is_c = 1
-    initial_strengths = [is_a, is_b, is_c]
-    atts = [('b', 'a')]
+    is_d = 1
+    initial_strengths = [is_a, is_b, is_c, is_d]
+    atts = [('b', 'a'), ('d','c')]
     supps = [('c', 'b')]
     qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics='basic_model')
     assert determine_iremoval_ctrb('a', 'b', qbaf) == -1    
     assert determine_iremoval_ctrb('a', 'c', qbaf) == -1
     assert determine_iremoval_ctrb('b', 'a', qbaf) == 0
+    assert determine_iremoval_ctrb('a', {'b','c'}, qbaf) == -2
+    assert determine_iremoval_ctrb('b', {'a','c'}, qbaf) == 1


### PR DESCRIPTION
CODE
Added functionality to determine_iremoval_ctrb() to quantify the contribution of a set of arguments to the final strength of another argument. This implementation assumes that the attacks and supports within the contributor set should remain.

determine_iremoval_ctrb() can now handle both a single contributor (single str) and a set of contributors (set of str).

DOCS
Updated docstring.

TESTS
Extended the tests for determine_iremoval_ctrb to include cases with a set of contributors.

The old and new tests are passing.