### PR TITLE
Refactor set-check

### DIFF
--- a/qbaf_ctrbs/intrinsic_removal.py
+++ b/qbaf_ctrbs/intrinsic_removal.py
@@ -13,13 +13,13 @@ def determine_iremoval_ctrb(topic, contributors, qbaf):
     Returns:
         float: The contribution of the contributor to the topic
     """
+    if not isinstance(contributors, set):
+        contributors = {contributors}
     if topic in contributors:
         raise Exception (
             'An argument\'s intrinsic removal contribution to itself cannot be determined.')
     if not all(item in qbaf.arguments for item in [topic, *contributors]):
         raise Exception ('Topic and contributor must be in the QBAF.')
-    if not isinstance(contributors, set):
-        contributors = {contributors}
     attackers = [(source, target) for source, target in qbaf.attack_relations.relations if (source in contributors or target not in contributors)]
     supporters = [(source, target) for source, target in qbaf.support_relations.relations if (source in contributors or target not in contributors)]
     arguments = list(qbaf.arguments)

--- a/qbaf_ctrbs/removal.py
+++ b/qbaf_ctrbs/removal.py
@@ -2,7 +2,7 @@ from qbaf_ctrbs.utils import restrict
 
 def determine_removal_ctrb(topic, contributors, qbaf):
     """Determines the removal contribution of a contributor
-    to a topic argument.
+    or a set of contributors to a topic argument.
 
     Args:
         topic (string): The topic argument
@@ -12,15 +12,13 @@ def determine_removal_ctrb(topic, contributors, qbaf):
     Returns:
         float: The contribution of the contributor to the topic
     """
+    if not isinstance(contributors, set):
+        contributors = {contributors}
     if topic in contributors:
         raise Exception (
             'An argument\'s removal contribution to itself cannot be determined.')
-    # Ensure topic and argument(s) are in QBAF.
     if not all(item in qbaf.arguments for item in [topic, *contributors]):
             raise Exception ('Topic and contributor must be in the QBAF.')
-    # Check if input is a set of arguments (type: set) or single argument (type: string).
-    if not isinstance(contributors, set):
-        contributors = {contributors}
     fs_with = qbaf.final_strengths[topic]
     restriction = restrict(qbaf, qbaf.arguments - contributors)
     fs_without = restriction.final_strengths[topic]

--- a/qbaf_ctrbs/shapley.py
+++ b/qbaf_ctrbs/shapley.py
@@ -19,13 +19,13 @@ def determine_shapley_ctrb(topic, contributors, qbaf):
     Returns:
         float: The contribution of the contributor to the topic
     """
+    if not isinstance(contributors, set):
+        contributors = {contributors}
     if topic in contributors:
         raise Exception (
             'An argument\'s shapley contribution to itself cannot be determined.')
     if not all(item in qbaf.arguments for item in [topic, *contributors]):
             raise Exception ('Topic and contributor must be in the QBAF.')
-    if not isinstance(contributors, set):
-        contributors = {contributors}
     sub_ctrbs = []
     reduced_args = [arg for arg in qbaf.arguments if arg not in [*contributors, topic]]
     subsets = determine_powerset(reduced_args)


### PR DESCRIPTION
As discussed, this PR refactors the set-check to ensure contributors is a set before performing validation.
This change has been applied to **removal.py**, **intrinsic_removal.py**, and **shapley.py**.

Additionally, I cleaned up excess comments in **removal.py** to maintain a more consistent style across functions.

All tests are passing.

Let me know if I should change anything or if there's anything else that needs tweaking.