### PR TITLE
Added support for set of contributors in gradient.

### DIFF
--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -1,6 +1,17 @@
 from qbaf import QBAFramework
 from qbaf_ctrbs.gradient import determine_gradient_ctrb
 
+
+def test_gradient_set():
+    args = ['a', 'b', 'c', 'd', 'e']
+    initial_strengths = [0.5, 0, 0, 0, 0.5]
+    atts = [('b', 'e'), ('c', 'e')]
+    supps = [('a', 'b'), ('a', 'c'), ('a', 'd'), ('d', 'e')]
+    qbaf = QBAFramework(args, initial_strengths, atts, supps, semantics='DFQuAD_model')
+
+    assert determine_gradient_ctrb('e', {'a', 'b'}, qbaf) >= determine_gradient_ctrb('e', {'b'}, qbaf)
+    assert determine_gradient_ctrb('e', {'b', 'c', 'd'}, qbaf) >= determine_gradient_ctrb('e', {'b','c'}, qbaf)
+
 def test_gradient():
     args = ['a', 'b', 'c', 'd', 'e']
     initial_strengths = [0.5, 0, 0, 0, 0.5]


### PR DESCRIPTION
CODE
This update extends determine_gradient_ctrb to quantify the contribution of a set of arguments to the final strength of another argument.

determine_gradient_ctrb can now handle both a single contributor (single str) and a set of contributors (set of str).

The function computes the gradient for each contributor and applies an aggregation function (defaults to max). The aggregation function can be specified as an input parameter. As a result, determine_gradient_ctrb will always return the maximum value (considering the sign), even if there exists a larger **absolute** contribution.

DOCS
Updated docstring.

TESTS
Extended the tests for determine_gradient_ctrb by adding cases with sets of contributors. The new tests follow the principle of **monotonicity**.

All previous and new assertions pass.