### PR TITLE
Partitioned shapley

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ Contribution Functions
    .. autofunction:: qbaf_ctrbs.removal.determine_removal_ctrb
    .. autofunction:: qbaf_ctrbs.intrinsic_removal.determine_iremoval_ctrb
    .. autofunction:: qbaf_ctrbs.shapley.determine_shapley_ctrb
+   .. autofunction:: qbaf_ctrbs.shapley.determine_partitioned_shapley_ctrb
    .. autofunction:: qbaf_ctrbs.gradient.determine_gradient_ctrb
    .. autofunction:: qbaf_ctrbs.utils.restrict
 

--- a/qbaf_ctrbs/shapley.py
+++ b/qbaf_ctrbs/shapley.py
@@ -37,3 +37,50 @@ def determine_shapley_ctrb(topic, contributors, qbaf):
         sub_ctrb = weight * (qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic])
         sub_ctrbs.append(sub_ctrb)
     return sum(sub_ctrbs)
+
+
+
+def determine_partitioned_shapley_ctrb(topic, contributors, partition, qbaf):
+    """Determines the shapley contribution of a contributor
+    or a set of contributors to a topic argument for a given argument partition.
+
+    Args:
+        topic (string): The topic argument
+        contributors (string or set): The contributing argument(s)
+        partition (set): The argument partitioning
+        qbaf (QBAFramework): The QBAF that contains topic and contributor
+
+    Returns:
+        float: The contribution of the contributor to the topic
+    """
+    if not isinstance(contributors, set):
+        contributors = {contributors}
+    if topic in contributors:
+        raise Exception (
+            'An argument\'s shapley contribution to itself cannot be determined.')
+    if not all(item in qbaf.arguments for item in [topic, *contributors]):
+            raise Exception ('Topic and contributor must be in the QBAF.')
+    if ({topic} not in partition) or (contributors not in partition):
+         raise Exception ('Topic and contributor must be part of the given partition.')
+
+    partitioned_args = set().union(*partition) # Flatten list of sets into one set.
+    if partitioned_args != set(qbaf.arguments):
+         raise Exception('The partition is incomplete.')
+    total_len = sum(len(s) for s in partition)
+    if total_len != len(partitioned_args):
+         raise Exception('Too many arguments in the partition (might not be disjoint).')
+
+    sub_ctrbs = []
+    reduced_partition = [frozenset(part) for part in partition if part not in [{topic}, contributors]]
+    subsets = determine_powerset(reduced_partition)
+    for subset in subsets:
+        targets = {topic} | set().union(*subset)
+        qbaf_without = restrict(qbaf, list(targets))
+
+        targets |= contributors
+        qbaf_with = restrict(qbaf, list(targets))
+
+        weight = (math.factorial(len(subset)) * math.factorial(len(qbaf.arguments)-1-len(subset)-len(contributors)))/math.factorial(len(qbaf.arguments)-1-len(contributors)+1)
+        sub_ctrb = weight * (qbaf_with.final_strengths[topic] - qbaf_without.final_strengths[topic])
+        sub_ctrbs.append(sub_ctrb)
+    return sum(sub_ctrbs)

--- a/tests/test_shapley.py
+++ b/tests/test_shapley.py
@@ -56,17 +56,21 @@ def test_grouped_partition_for_two_contributors():
 
 def test_error_on_invalid_partition():
     qbaf = make_qbaf()
-    bad_partition = [{'a'}, {'b'}] # Missing {'b'}.
+    bad_partition = [{'a'}, {'b'}] # Missing {'c'}.
     with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b'}, bad_partition, qbaf)
 
-    bad_partition = [{'a'}, {'c'}] # Missing {'c'}.
-    with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b'}, bad_partition, qbaf)
+    bad_partition = [{'a'}, {'c'}] # Missing {'b'}.
+    with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'c'}, bad_partition, qbaf)
 
     bad_partition = [{'a'}, {'b'}, {'c'}, {'d'}] # Extra {'d'}.
     with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b'}, bad_partition, qbaf)
 
     bad_partition = [{'a'}, {'b', 'c'}, {'c'}] # Not disjoint.
-    with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b'}, bad_partition, qbaf)
+    with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b', 'c'}, bad_partition, qbaf)
+
+    # Contributor not in partition.
+    bad_partition = [{'a'}, {'b'}, {'c'}]
+    with pytest.raises(Exception): determine_partitioned_shapley_ctrb('a', {'b','c'}, bad_partition, qbaf)
 
 def test_single_arg_partition():
     qbaf = make_qbaf()
@@ -79,6 +83,6 @@ def test_multi_arg_partition():
     qbaf = make_qbaf()
     partition = [{'a', 'b'}, {'c'}]
     assert determine_partitioned_shapley_ctrb('c', {'a', 'b'}, partition, qbaf) == 0
-    
+
     partition = [{'a'}, {'b', 'c'}]
     assert determine_partitioned_shapley_ctrb('a', {'b', 'c'}, partition, qbaf) == -2


### PR DESCRIPTION
CODE
Implemented determine_partitioned_shapley_ctrb. This function "extends" determine_shapley_ctrb to take a argument partition as input and calculate the Shapley value for a given contributor (set or single argument) relative to the given partition.

DOCS
Docstring documentation in determine_partitioned_shapley_ctrb.
Added ".. autofunction:: qbaf_ctrbs.shapley.determine_partitioned_shapley_ctrb" to index.rst (Sphinx documentation).

TESTS
Implemented tests for determine_partitioned_shapley_ctrb in the same file as the tests for determine_shapley_ctrb (i.e. test_shapley.py).