### PR TITLE
Cycles

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,17 +1,125 @@
-.. qbaf-py documentation master file, created by
-   sphinx-quickstart on Fri Dec  2 20:07:06 2022.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to QBAF-Py's documentation!
+QBAF-Py Documentation
 ===================================
-QBAF-Py is a library for drawing inferences from Quantitative Bipolar Argumentation Frameworks (QBAFs) and explaining them. The library is written in CPython (C with a Python API) to facilitate speed and efficiency.
+QBAF-Py is a library for drawing inferences from Quantitative Bipolar Argumentation Frameworks (QBAFs) and explaining them.
+The library is written in CPython (C with a Python API) to facilitate speed and efficiency.
 
-Core API
-########
+To use QBAF-Py, the main object to create is a ``QBAFramework``. At a high level, a framework is built from four pieces:
 
-.. automodule:: qbaf
-   :members:
+- the arguments in the graph,
+- the initial strength of each argument,
+- the attack relations,
+- the support relations.
+
+So the user describes which arguments exist, how strong they are initially, and how they influence one another.
+
+For example, a small framework can be created like this:
+
+.. code-block:: python
+
+   from qbaf import QBAFramework
+
+   qbaf = QBAFramework(
+       ["A", "B", "C"],
+       [0.8, 0.4, 0.7],
+       [("B", "A")],
+       [("C", "A")],
+       semantics="DFQuAD_model",
+   )
+
+Here, ``B`` attacks ``A``, ``C`` supports ``A``, and ``semantics`` specifies how those interactions are turned into final strengths.
+
+The supported semantics are:
+
+- Basic model: ``"basic_model"``
+- Quadratic Energy: ``"QuadraticEnergy_model"``
+- Squared DF-QuAD: ``"SquaredDFQuAD_model"``
+- Euler-Based Top: ``"EulerBasedTop_model"``
+- Euler-Based: ``"EulerBased_model"``
+- DF-QuAD: ``"DFQuAD_model"``
+
+Once the framework has been created, you can inspect whether it is acyclic and what final strengths it assigns:
+
+.. code-block:: python
+
+   qbaf.final_strengths
+   qbaf.final_strength("A")
+
+
+
+To understand how different arguments affect a topic argument, QBAF-Py provides several contribution functions, supporting both individual contributors and sets of contributors.
+
+The available contribution functions are:
+
+- Removal contribution: ``determine_removal_ctrb``
+- Intrinsic removal contribution: ``determine_iremoval_ctrb``
+- Shapley contribution: ``determine_shapley_ctrb``
+- Partitioned Shapley contribution: ``determine_partitioned_shapley_ctrb``
+- Gradient contribution: ``determine_gradient_ctrb``
+
+For example, to compute the removal contribution of ``C`` to ``A``:
+
+.. code-block:: python
+
+   from qbaf_ctrbs.removal import determine_removal_ctrb
+
+   contribution = determine_removal_ctrb("A", "C", qbaf)
+   print(contribution)
+
+Cyclic Frameworks
+#################
+
+QBAF-Py also supports cyclic frameworks.
+A framework can contain cycles through its attack and support relations, and you can check this with ``qbaf.isacyclic()``.
+
+By default, cycle handling is disabled.
+This means that if the framework is cyclic, accessing ``final_strengths`` raises an error unless cycle support is enabled explicitly.
+To evaluate a cyclic framework, you can enable cycle support by passing ``allow_cycles=True``.
+To control the convergence criteria, you can also pass the following arguments when constructing it:
+
+- ``max_iterations`` (default ``1000``)
+- ``convergence_threshold`` (default ``1e-9``)
+
+For example:
+
+.. code-block:: python
+
+   cyclic_qbaf = QBAFramework(
+       ["A", "B"],
+       [1.0, 0.5],
+       [("A", "B"), ("B", "A")],
+       [],
+       semantics="DFQuAD_model",
+       allow_cycles=True,
+       max_iterations=1000,
+       convergence_threshold=1e-9,
+   )
+
+   cyclic_qbaf.isacyclic()
+   cyclic_qbaf.final_strengths
+
+When cycle support is enabled, QBAF-Py computes final strengths by synchronous fixed-point iteration.
+It starts from the initial strengths, updates all arguments from the previous iteration, and stops once the change is below the convergence threshold.
+If convergence is not reached within ``max_iterations``, a ``RuntimeError`` is raised.
+
+.. note::
+
+   Whether a cyclic framework converges or not can depend on the chosen semantics.
+
+The cycle-related settings are exposed on the framework instance through:
+
+- ``allow_cycles`` (``bool``)
+- ``max_iterations`` (``int``)
+- ``convergence_threshold`` (``float``)
+
+
+
+
+
+
+
+
+
+
 
 Contribution Functions
 ######################
@@ -22,6 +130,22 @@ Contribution Functions
    .. autofunction:: qbaf_ctrbs.shapley.determine_partitioned_shapley_ctrb
    .. autofunction:: qbaf_ctrbs.gradient.determine_gradient_ctrb
    .. autofunction:: qbaf_ctrbs.utils.restrict
+
+
+Visualization Support
+#####################
+
+   .. autofunction:: qbaf_visualizer.Visualizer.visualize
+
+
+
+Core API
+########
+
+.. automodule:: qbaf
+   :members:
+
+
 
 Robustness Functions
 ####################
@@ -37,9 +161,3 @@ Robustness Functions
    .. autofunction:: qbaf_robustness.explanations.is_pocket
    .. autofunction:: qbaf_robustness.explanations.pockets_of_consistency
    .. autofunction:: qbaf_robustness.explanations.explanation_of_robustness_violation
-   
-Visualization Support
-#####################
-
-   .. autofunction:: qbaf_visualizer.Visualizer.visualize
-

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,14 +19,14 @@ For example, a small framework can be created like this:
    from qbaf import QBAFramework
 
    qbaf = QBAFramework(
-       ["A", "B", "C"],
+       ['a', 'b', 'c'],
        [0.8, 0.4, 0.7],
-       [("B", "A")],
-       [("C", "A")],
+       [('b', 'a')],
+       [('c', 'a')],
        semantics="DFQuAD_model",
    )
 
-Here, ``B`` attacks ``A``, ``C`` supports ``A``, and ``semantics`` specifies how those interactions are turned into final strengths.
+Here, ``b`` attacks ``a``, ``c`` supports ``a``, and ``semantics`` specifies how those interactions are turned into final strengths.
 
 The supported semantics are:
 
@@ -42,7 +42,7 @@ Once the framework has been created, you can inspect whether it is acyclic and w
 .. code-block:: python
 
    qbaf.final_strengths
-   qbaf.final_strength("A")
+   qbaf.final_strength('a')
 
 
 
@@ -56,13 +56,13 @@ The available contribution functions are:
 - Partitioned Shapley contribution: ``determine_partitioned_shapley_ctrb``
 - Gradient contribution: ``determine_gradient_ctrb``
 
-For example, to compute the removal contribution of ``C`` to ``A``:
+For example, to compute the removal contribution of ``c`` to ``a``:
 
 .. code-block:: python
 
    from qbaf_ctrbs.removal import determine_removal_ctrb
 
-   contribution = determine_removal_ctrb("A", "C", qbaf)
+   contribution = determine_removal_ctrb('a', 'c', qbaf)
    print(contribution)
 
 Cyclic Frameworks
@@ -84,9 +84,9 @@ For example:
 .. code-block:: python
 
    cyclic_qbaf = QBAFramework(
-       ["A", "B"],
+       ['a', 'b'],
        [1.0, 0.5],
-       [("A", "B"), ("B", "A")],
+       [('a', 'b'), ('b', 'a')],
        [],
        semantics="DFQuAD_model",
        allow_cycles=True,

--- a/qbaf_ctrbs/gradient.py
+++ b/qbaf_ctrbs/gradient.py
@@ -30,7 +30,10 @@ def determine_gradient_ctrb(topic, contributors, qbaf, epsilon=1.490116119384765
         qbaf_changed = QBAFramework(argument_list, initial_strengths,
                                     qbaf.attack_relations.relations,
                                     qbaf.support_relations.relations,
-                                    semantics=qbaf.semantics)
+                                    semantics=qbaf.semantics,
+                                    allow_cycles=qbaf.allow_cycles,
+                                    max_iterations=qbaf.max_iterations,
+                                    convergence_threshold=qbaf.convergence_threshold)
         return qbaf_changed.final_strength(topic)
     
     all_contributors_strength = [(contributor, qbaf.initial_strength(contributor)) for contributor in contributors]

--- a/qbaf_ctrbs/utils.py
+++ b/qbaf_ctrbs/utils.py
@@ -1,6 +1,8 @@
 from itertools import chain, combinations
 from qbaf import QBAFramework
 
+
+
 def restrict(qbaf, arguments):
     """Restricts the given QBAF to the provided set of arguments.
 
@@ -19,7 +21,16 @@ def restrict(qbaf, arguments):
             restriction_is.append(strength)
     restriction_atts = [(source, target) for source, target in qbaf.attack_relations.relations if source in arguments and target in arguments]
     restriction_supps = [(source, target) for source, target in qbaf.support_relations.relations if source in arguments and target in arguments]
-    return QBAFramework(new_args, restriction_is, restriction_atts, restriction_supps, semantics=qbaf.semantics)
+    return QBAFramework(new_args,
+                        restriction_is,
+                        restriction_atts,
+                        restriction_supps,
+                        semantics=qbaf.semantics,
+                        allow_cycles=qbaf.allow_cycles,
+                        max_iterations=qbaf.max_iterations,
+                        convergence_threshold=qbaf.convergence_threshold)
+
+
 
 def determine_powerset(elements):
     """Determines the powerset of a list of elements

--- a/src/framework.c
+++ b/src/framework.c
@@ -1533,57 +1533,47 @@ QBAFramework_copy(QBAFrameworkObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 /**
- * @brief Return a list with the arguments that are being attacked/supported by Argument argument (itself included)
- * that are in a cycle, NULL if an error has occurred.
+ * @brief Return 1 if argument reaches a cycle through attack/support relations, 0 if not,
+ * -1 if an error has occurred.
  * 
  * @param self an instance of QBAFramework
  * @param argument an instance of QBAFArgument
  * @param not_visited a PySet of QBAFArgument that have not been visited yet (this set is modified in this function)
  * @param visiting a PySet of QBAFArgument that are being visited within this function
- * @return PyObject* a new PyList of QBAFArgument objects that contain at least one cycle 
+ * @return int 1 if a cycle is found, 0 if not, -1 if an error occurred
  */
-static PyObject *
-_QBAFramework_incycle_arguments(QBAFrameworkObject *self, PyObject *argument, PyObject *not_visited, PyObject *visiting)
+static int
+_QBAFramework_has_cycle_from(QBAFrameworkObject *self, PyObject *argument, PyObject *not_visited, PyObject *visiting)
 {
     int contains = PySet_Contains(visiting, argument);
     if (contains < 0) {
-        return NULL;
+        return -1;
     }
-    if (contains) { // If argument is being visited, do not visit it again but return it
-        PyObject *list = PyList_New(1);
-        if (list == NULL)
-            return NULL;
-        Py_INCREF(argument);
-        PyList_SET_ITEM(list, 0, argument);
-        return list;
+    if (contains) {// If argument is being visited, a cycle was found
+        return 1;
     }
 
-    if (PySet_Add(visiting, argument) < 0) {    // We add the argument to visiting
-        return NULL;
+    if (PySet_Add(visiting, argument) < 0) { // We add the argument to visiting
+        return -1;
     }
     PyObject *attack_patients, *support_patients;
-    PyObject *patients, *result, *previous_result, *incycle;
+    PyObject *patients;
 
     attack_patients = _QBAFARelations_patients((QBAFARelationsObject*)self->attack_relations, argument);
     if (attack_patients == NULL) {
-        return NULL;
+        return -1;
     }
     support_patients = _QBAFARelations_patients((QBAFARelationsObject*)self->support_relations, argument);
     if (support_patients == NULL) {
         Py_DECREF(attack_patients);
+        return -1;
     }
 
     patients = PyList_Concat(attack_patients, support_patients);
     Py_DECREF(attack_patients);
     Py_DECREF(support_patients);
     if (patients == NULL) {
-        return NULL;
-    }
-
-    result = PyList_New(0);
-    if (result == NULL) {
-        Py_DECREF(patients);
-        return NULL;
+        return -1;
     }
 
     PyObject *iterator = PyObject_GetIter(patients);
@@ -1591,34 +1581,28 @@ _QBAFramework_incycle_arguments(QBAFrameworkObject *self, PyObject *argument, Py
 
     if (iterator == NULL) {
         Py_DECREF(patients);
-        Py_DECREF(result);
-        return NULL;
+        return -1;
     }
 
     while ((item = PyIter_Next(iterator))) {    // PyIter_Next returns a new reference
         contains = PySet_Contains(not_visited, item);
         if (contains < 0) {
-            Py_DECREF(patients); Py_DECREF(result);
+            Py_DECREF(patients);
             Py_DECREF(iterator); Py_DECREF(item);
-            return NULL;
+            return -1;
         }
 
         if (contains) {
-            previous_result = result;
-            incycle = _QBAFramework_incycle_arguments(self, item, not_visited, visiting);
-            if (incycle == NULL) {
-                Py_DECREF(patients); Py_DECREF(previous_result);
-                Py_DECREF(iterator); Py_DECREF(item);
-                return NULL;
-            }
-
-            result = PyList_Concat(previous_result, incycle);
-            Py_DECREF(previous_result);
-            Py_DECREF(incycle);
-            if (result == NULL) {
+            int has_cycle = _QBAFramework_has_cycle_from(self, item, not_visited, visiting);
+            if (has_cycle < 0) {
                 Py_DECREF(patients);
                 Py_DECREF(iterator); Py_DECREF(item);
-                return NULL;
+                return -1;
+            }
+            if (has_cycle) {
+                Py_DECREF(patients);
+                Py_DECREF(iterator); Py_DECREF(item);
+                return 1;
             }
         }
 
@@ -1629,16 +1613,14 @@ _QBAFramework_incycle_arguments(QBAFrameworkObject *self, PyObject *argument, Py
     Py_DECREF(patients);
 
     if (PySet_Discard(not_visited, argument) < 0) { // We remove the argument from not visited
-        Py_DECREF(result);
-        return NULL;
+        return -1;
     }
 
     if (PySet_Discard(visiting, argument) < 0) { // We remove the argument from visiting
-        Py_DECREF(result);
-        return NULL;
+        return -1;
     }
 
-    return result;
+    return 0;
 }
 
 /**
@@ -1663,24 +1645,21 @@ _QBAFramework_isacyclic(QBAFrameworkObject *self)
         return -1;
     }
 
-    PyObject *argument, *incycle;
+    PyObject *argument;
 
     while (PySet_GET_SIZE(not_visited) > 0) {
         argument = PySet_Pop(not_visited);  // New reference. Unchecked errors
         PySet_Add(not_visited, argument);   // We return the argument to the set
+        int has_cycle = _QBAFramework_has_cycle_from(self, argument, not_visited, visiting);
         Py_DECREF(argument);
-
-        incycle = _QBAFramework_incycle_arguments(self, argument, not_visited, visiting);
-        if (incycle == NULL) {
+        if (has_cycle < 0) {
             Py_DECREF(visiting); Py_DECREF(not_visited);
             return -1;
         }
-        if (PyList_GET_SIZE(incycle) > 0) { // If detected cycle
+        if (has_cycle) { // If detected cycle
             Py_DECREF(visiting); Py_DECREF(not_visited);
-            Py_DECREF(incycle);
             return 0; // Return False
         }
-        Py_DECREF(incycle);
     }
 
     Py_DECREF(visiting);
@@ -1740,8 +1719,6 @@ _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argum
     }
 
     PyObject *iterator = PyObject_GetIter(attackers);
-    PyObject *item;
-
     if (iterator == NULL) {
         Py_DECREF(attackers);
         return -1.0;
@@ -1760,8 +1737,9 @@ _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argum
         return -1.0;
     }
     
+    PyObject *item;
     Py_ssize_t index = 0;
-    while ((item = PyIter_Next(iterator))) {    // PyIter_Next returns a new reference
+    while ((item = PyIter_Next(iterator))) { // PyIter_Next returns a new reference
         double strength = _QBAFramework_calculate_final_strength(self, item);
         Py_DECREF(item);
         if (strength == -1.0 && PyErr_Occurred()) {
@@ -1888,7 +1866,7 @@ _QBAFRamework_calculate_final_strengths(QBAFrameworkObject *self)
         return -1;
     }
 
-    while ((item = PyIter_Next(iterator))) {    // PyIter_Next returns a new reference
+    while ((item = PyIter_Next(iterator))) { // PyIter_Next returns a new reference
         if (_QBAFramework_calculate_final_strength(self, item) == -1.0 && PyErr_Occurred()) {
             Py_DECREF(item); Py_DECREF(iterator);
             return -1;

--- a/src/framework.c
+++ b/src/framework.c
@@ -61,6 +61,9 @@ typedef struct {
     double  (*aggregation_function)(PyObject*, PyObject*); /* aggregation function that is going to be used to calcualte the final strengths */
     double    min_strength;           /* min value for the initial strengths */
     double    max_strength;           /* max value for the initial strengths */
+    int       allow_cycles;           /* 1 if cyclic frameworks should be evaluated iteratively, 0 otherwise */
+    Py_ssize_t max_iterations;        /* maximum number of synchronous iterations for cyclic frameworks */
+    double    convergence_threshold;  /* convergence threshold for cyclic frameworks */
     PyObject *influence_function_callable;   /* influence function given from python */
     PyObject *aggregation_function_callable; /* aggregation function given from python */
 } QBAFrameworkObject;
@@ -149,6 +152,9 @@ QBAFramework_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         self->aggregation_function = sum;
         self->min_strength = -DBL_MAX;
         self->max_strength = DBL_MAX;
+        self->allow_cycles = FALSE;
+        self->max_iterations = 1000;
+        self->convergence_threshold = 1e-9;
         self->influence_function_callable = NULL;
         self->aggregation_function = NULL;
     }
@@ -351,17 +357,20 @@ QBAFramework_init(QBAFrameworkObject *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"arguments", "initial_strengths", "attack_relations", "support_relations",
                             "disjoint_relations", "semantics", "aggregation_function", "influence_function",
-                            "min_strength", "max_strength", NULL};
+                            "min_strength", "max_strength", "allow_cycles", "max_iterations", "convergence_threshold", NULL};
     PyObject *arguments, *initial_strengths, *attack_relations, *support_relations, *tmp;
     int disjoint_relations = TRUE;
     char *semantics = NULL; // (e.g. "basic_model") If None it will be NULL, otherwise it is a pointer to char that is only accesible in this function.
     PyObject *aggregation_function = NULL, *influence_function = NULL;
     double min_strength = -DBL_MAX, max_strength = DBL_MAX;
+    int allow_cycles = FALSE;
+    Py_ssize_t max_iterations = 1000;
+    double convergence_threshold = 1e-9;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|pzOOdd", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|pzOOddpnd", kwlist,
                                      &arguments, &initial_strengths, &attack_relations, &support_relations,
                                      &disjoint_relations, &semantics, &aggregation_function, &influence_function,
-                                     &min_strength, &max_strength))
+                                     &min_strength, &max_strength, &allow_cycles, &max_iterations, &convergence_threshold))
         return -1;
 
     if (!PyList_Check(arguments)) {
@@ -448,6 +457,18 @@ QBAFramework_init(QBAFrameworkObject *self, PyObject *args, PyObject *kwds)
 
     
     self->disjoint_relations = disjoint_relations;
+    self->allow_cycles = allow_cycles;
+    self->max_iterations = max_iterations;
+    self->convergence_threshold = convergence_threshold;
+
+    if (self->max_iterations <= 0) {
+        PyErr_SetString(PyExc_ValueError, "max_iterations must be greater than 0");
+        return -1;
+    }
+    if (self->convergence_threshold <= 0.0) {
+        PyErr_SetString(PyExc_ValueError, "convergence_threshold must be greater than 0");
+        return -1;
+    }
 
     if (self->disjoint_relations) {
         // Check attack and support relations are disjoint
@@ -739,6 +760,24 @@ static PyObject *
 QBAFramework_getmax_strength(QBAFrameworkObject *self, void *closure)
 {
     return PyFloat_FromDouble(self->max_strength);
+}
+
+static PyObject *
+QBAFramework_getallow_cycles(QBAFrameworkObject *self, void *closure)
+{
+    Py_RETURN_BOOL(self->allow_cycles);
+}
+
+static PyObject *
+QBAFramework_getmax_iterations(QBAFrameworkObject *self, void *closure)
+{
+    return PyLong_FromSsize_t(self->max_iterations);
+}
+
+static PyObject *
+QBAFramework_getconvergence_threshold(QBAFrameworkObject *self, void *closure)
+{
+    return PyFloat_FromDouble(self->convergence_threshold);
 }
 
 /**
@@ -1524,6 +1563,9 @@ QBAFramework_copy(QBAFrameworkObject *self, PyObject *Py_UNUSED(ignored))
     copy->influence_function = self->influence_function;
     copy->min_strength = self->min_strength;
     copy->max_strength = self->max_strength;
+    copy->allow_cycles = self->allow_cycles;
+    copy->max_iterations = self->max_iterations;
+    copy->convergence_threshold = self->convergence_threshold;
 
     Py_XINCREF(self->aggregation_function_callable);
     copy->aggregation_function_callable = self->aggregation_function_callable;
@@ -1691,29 +1733,6 @@ QBAFramework_isacyclic(QBAFrameworkObject *self, PyObject *Py_UNUSED(ignored))
     Py_RETURN_FALSE;
 }
 
-
-/**
- * @brief Decrease the reference count of each given PyObject and return -1.0.
- *
- * @param number_of_objects the number of PyObject* arguments that follow
- * @return double always -1.0
- */
-static double
-_QBAFramework_decref_on_error(Py_ssize_t number_of_objects, ...)
-{
-    va_list objects_to_decref;
-    va_start(objects_to_decref, number_of_objects);
-
-    for (Py_ssize_t object_index = 0; object_index < number_of_objects; object_index++) {
-        PyObject *current_object = va_arg(objects_to_decref, PyObject *);
-        Py_XDECREF(current_object);
-    }
-
-    va_end(objects_to_decref);
-    return -1.0;
-}
-
-
 /**
  * @brief Append argument to argument_stack.
  *
@@ -1788,12 +1807,12 @@ _QBAFramework_push_unresolved_dependencies(QBAFrameworkObject *self, PyObject *c
     }
 
     PyObject *dependency_iterator = PyObject_GetIter(dependencies);
-    PyObject *dependency_argument;
     if (dependency_iterator == NULL) {
         Py_DECREF(dependencies);
         return -1;
     }
 
+    PyObject *dependency_argument;
     while ((dependency_argument = PyIter_Next(dependency_iterator))) {
         int dependency_has_calculated_strength = PyDict_Contains(self->final_strengths, dependency_argument);
         if (dependency_has_calculated_strength < 0) {
@@ -1846,7 +1865,7 @@ _QBAFramework_push_unresolved_dependencies(QBAFrameworkObject *self, PyObject *c
  * @return PyObject* a new PyList of PyFloat
  */
 static PyObject *
-_QBAFramework_retrieve_computed_strengths(QBAFrameworkObject *self, PyObject *arguments)
+_QBAFramework_retrieve_computed_strengths(PyObject *strengths_by_argument, PyObject *arguments)
 {
     Py_ssize_t number_of_arguments = PyObject_Size(arguments);
     if (number_of_arguments == -1) {
@@ -1867,7 +1886,7 @@ _QBAFramework_retrieve_computed_strengths(QBAFrameworkObject *self, PyObject *ar
 
     Py_ssize_t argument_index = 0;
     while ((current_argument = PyIter_Next(argument_iterator))) {
-        int has_calculated_strength = PyDict_Contains(self->final_strengths, current_argument);
+        int has_calculated_strength = PyDict_Contains(strengths_by_argument, current_argument);
         if (has_calculated_strength < 0) {
             Py_DECREF(current_argument);
             Py_DECREF(argument_iterator);
@@ -1882,7 +1901,7 @@ _QBAFramework_retrieve_computed_strengths(QBAFrameworkObject *self, PyObject *ar
             return NULL;
         }
 
-        double current_strength = PyFloat_AsDouble(PyDict_GetItem(self->final_strengths, current_argument));
+        double current_strength = PyFloat_AsDouble(PyDict_GetItem(strengths_by_argument, current_argument));
         Py_DECREF(current_argument);
         if (current_strength == -1.0 && PyErr_Occurred()) {
             Py_DECREF(argument_iterator);
@@ -1914,7 +1933,8 @@ _QBAFramework_retrieve_computed_strengths(QBAFrameworkObject *self, PyObject *ar
  * @return int 0 if successful, -1 otherwise
  */
 static int
-_QBAFramework_calculate_argument_with_resolved_dependencies(QBAFrameworkObject *self, PyObject *current_argument)
+_QBAFramework_apply_semantics(QBAFrameworkObject *self, PyObject *current_argument,
+                              PyObject *dependency_strengths_by_argument, PyObject *strengths_to_update)
 {
     PyObject *attackers = _QBAFARelations_agents((QBAFARelationsObject*)self->attack_relations, current_argument);
     if (attackers == NULL) {
@@ -1927,14 +1947,14 @@ _QBAFramework_calculate_argument_with_resolved_dependencies(QBAFrameworkObject *
         return -1;
     }
 
-    PyObject *attacker_strengths = _QBAFramework_retrieve_computed_strengths(self, attackers);
+    PyObject *attacker_strengths = _QBAFramework_retrieve_computed_strengths(dependency_strengths_by_argument, attackers);
     if (attacker_strengths == NULL) {
         Py_DECREF(attackers);
         Py_DECREF(supporters);
         return -1;
     }
 
-    PyObject *supporter_strengths = _QBAFramework_retrieve_computed_strengths(self, supporters);
+    PyObject *supporter_strengths = _QBAFramework_retrieve_computed_strengths(dependency_strengths_by_argument, supporters);
     Py_DECREF(attackers);
     Py_DECREF(supporters);
     if (supporter_strengths == NULL) {
@@ -1963,7 +1983,7 @@ _QBAFramework_calculate_argument_with_resolved_dependencies(QBAFrameworkObject *
     if (final_strength_object == NULL) {
         return -1;
     }
-    if (PyDict_SetItem(self->final_strengths, current_argument, final_strength_object) < 0) {
+    if (PyDict_SetItem(strengths_to_update, current_argument, final_strength_object) < 0) {
         Py_DECREF(final_strength_object);
         return -1;
     }
@@ -1984,8 +2004,7 @@ _QBAFramework_calculate_argument_with_resolved_dependencies(QBAFrameworkObject *
 static double
 _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argument)
 {
-    // Check if it has been calculated already
-    int contains = PyDict_Contains(self->final_strengths, argument);
+    int contains = PyDict_Contains(self->final_strengths, argument); // Check if it has been calculated already
     if (contains < 0) {
         return -1.0;
     }
@@ -1996,11 +2015,13 @@ _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argum
     PyObject *argument_stack = PyList_New(0);
     PyObject *arguments_on_stack = PySet_New(NULL);
     if (argument_stack == NULL || arguments_on_stack == NULL) {
-        return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        Py_XDECREF(argument_stack); Py_XDECREF(arguments_on_stack);
+        return -1.0;
     }
 
     if (_QBAFramework_argument_stack_push(argument_stack, argument) < 0) {
-        return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+        return -1.0;
     }
 
     while (PyList_GET_SIZE(argument_stack) > 0) {
@@ -2008,49 +2029,179 @@ _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argum
 
         contains = PyDict_Contains(self->final_strengths, current_argument);
         if (contains < 0) {
-            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+            return -1.0;
         }
         if (contains) {
             if (_QBAFramework_argument_stack_pop(argument_stack) < 0) {
-                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+                Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+                return -1.0;
             }
             if (PySet_Discard(arguments_on_stack, current_argument) < 0) {
-                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+                Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+                return -1.0;
             }
             continue;
         }
 
         int argument_is_on_stack = PySet_Contains(arguments_on_stack, current_argument);
         if (argument_is_on_stack < 0) {
-            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+            return -1.0;
         }
 
         // On first visit push dependencies. On second visit calculate final strength.
         if (!argument_is_on_stack) {
             if (PySet_Add(arguments_on_stack, current_argument) < 0) {
-                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+                Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+                return -1.0;
             }
 
             if (_QBAFramework_push_unresolved_dependencies(self, current_argument, argument_stack, arguments_on_stack) < 0) {
-                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+                Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+                return -1.0;
             }
             continue;
         }
 
-        if (_QBAFramework_calculate_argument_with_resolved_dependencies(self, current_argument) < 0) {
-            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        if (_QBAFramework_apply_semantics(self, current_argument, self->final_strengths, self->final_strengths) < 0) {
+            Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+            return -1.0;
         }
         if (_QBAFramework_argument_stack_pop(argument_stack) < 0) {
-            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+            return -1.0;
         }
         if (PySet_Discard(arguments_on_stack, current_argument) < 0) {
-            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            Py_DECREF(argument_stack); Py_DECREF(arguments_on_stack);
+            return -1.0;
         }
     }
-
     Py_DECREF(argument_stack);
     Py_DECREF(arguments_on_stack);
     return PyFloat_AsDouble(PyDict_GetItem(self->final_strengths, argument));
+}
+
+
+/**
+ * @brief Calculate one synchronous update of all argument strengths from dependency_strengths_by_argument.
+ *
+ * @param self an instance of QBAFramework
+ * @param dependency_strengths_by_argument strengths used as the read-only source for this iteration
+ * @return PyObject* a new PyDict with updated strengths, NULL if an error occurred
+ */
+static PyObject *
+_QBAFramework_calculate_next_strengths(QBAFrameworkObject *self, PyObject *dependency_strengths_by_argument)
+{
+    PyObject *updated_strengths = PyDict_New();
+    if (updated_strengths == NULL) {
+        return NULL;
+    }
+
+    PyObject *argument_iterator = PyObject_GetIter(self->arguments);
+    if (argument_iterator == NULL) {
+        Py_DECREF(updated_strengths);
+        return NULL;
+    }
+
+    PyObject *current_argument;
+    while ((current_argument = PyIter_Next(argument_iterator))) {
+        if (_QBAFramework_apply_semantics(self, current_argument, dependency_strengths_by_argument, updated_strengths) < 0) {
+            Py_DECREF(current_argument); Py_DECREF(argument_iterator); Py_DECREF(updated_strengths);
+            return NULL;
+        }
+        Py_DECREF(current_argument);
+    }
+
+    Py_DECREF(argument_iterator);
+    return updated_strengths;
+}
+
+
+/**
+ * @brief Return 1 if previous_strengths and updated_strengths differ by at most convergence_threshold for every argument.
+ *
+ * @param self an instance of QBAFramework
+ * @param previous_strengths strengths from the previous iteration
+ * @param updated_strengths strengths from the current iteration
+ * @return int 1 if converged, 0 if not converged, -1 if an error occurred
+ */
+static int
+_QBAFramework_strengths_have_converged(QBAFrameworkObject *self, PyObject *previous_strengths, PyObject *updated_strengths)
+{
+    PyObject *argument_iterator = PyObject_GetIter(self->arguments);
+    if (argument_iterator == NULL) {
+        return -1;
+    }
+
+    PyObject *current_argument;
+    while ((current_argument = PyIter_Next(argument_iterator))) {
+        double previous_strength = PyFloat_AsDouble(PyDict_GetItem(previous_strengths, current_argument));
+        if (previous_strength == -1.0 && PyErr_Occurred()) {
+            Py_DECREF(current_argument); Py_DECREF(argument_iterator);
+            return -1;
+        }
+
+        double updated_strength = PyFloat_AsDouble(PyDict_GetItem(updated_strengths, current_argument));
+        if (updated_strength == -1.0 && PyErr_Occurred()) {
+            Py_DECREF(current_argument); Py_DECREF(argument_iterator);
+            return -1;
+        }
+
+        double strength_difference = updated_strength - previous_strength;
+        if (strength_difference < 0.0) {
+            strength_difference = -strength_difference;
+        }
+        Py_DECREF(current_argument);
+
+        if (strength_difference > self->convergence_threshold) {
+            Py_DECREF(argument_iterator);
+            return FALSE;
+        }
+    }
+
+    Py_DECREF(argument_iterator);
+    return TRUE;
+}
+
+
+/**
+ * @brief Calculate final strengths for cyclic frameworks by synchronous fixed-point iteration.
+ *
+ * @param self the QBAFramework
+ * @return int 0 if successful, -1 if an error occurred
+ */
+static int
+_QBAFramework_calculate_cyclic_final_strengths(QBAFrameworkObject *self)
+{
+    PyObject *previous_strengths = PyDict_Copy(self->initial_strengths);
+    if (previous_strengths == NULL) {
+        return -1;
+    }
+
+    for (Py_ssize_t iteration = 0; iteration < self->max_iterations; iteration++) {
+        PyObject *updated_strengths = _QBAFramework_calculate_next_strengths(self, previous_strengths);
+        if (updated_strengths == NULL) {
+            Py_DECREF(previous_strengths);
+            return -1;
+        }
+
+        int strengths_have_converged = _QBAFramework_strengths_have_converged(self, previous_strengths, updated_strengths);
+        Py_DECREF(previous_strengths);
+        if (strengths_have_converged < 0) {
+            Py_DECREF(updated_strengths);
+            return -1;
+        }
+        if (strengths_have_converged) {
+            Py_CLEAR(self->final_strengths);
+            self->final_strengths = updated_strengths;
+            return 0;
+        }
+        previous_strengths = updated_strengths;
+    }
+    Py_DECREF(previous_strengths);
+    PyErr_Format(PyExc_RuntimeError, "cyclic framework did not converge within %zd iterations", self->max_iterations);
+    return -1;
 }
 
 
@@ -2069,32 +2220,34 @@ _QBAFRamework_calculate_final_strengths(QBAFrameworkObject *self)
         return -1;
     }
     if (!isacyclic) {
-        PyErr_SetString(PyExc_NotImplementedError,
-                        "calculate final strengths of non-acyclic framework not implemented");
-        return -1;
+        if (!self->allow_cycles) {
+            PyErr_SetString(PyExc_NotImplementedError, "calculate final strengths of cyclic framework requires allow_cycles=True");
+            return -1;
+        }
+        return _QBAFramework_calculate_cyclic_final_strengths(self);
     }
 
     Py_CLEAR(self->final_strengths);
     self->final_strengths = PyDict_New();
 
     PyObject *iterator = PyObject_GetIter(self->arguments);
-    PyObject *item;
     if (iterator == NULL) {
         return -1;
     }
 
+    PyObject *item;
     while ((item = PyIter_Next(iterator))) { // PyIter_Next returns a new reference
         if (_QBAFramework_calculate_final_strength(self, item) == -1.0 && PyErr_Occurred()) {
-            Py_DECREF(item); Py_DECREF(iterator);
+            Py_DECREF(item);
+            Py_DECREF(iterator);
             return -1;
         }
         Py_DECREF(item);
     }
-
     Py_DECREF(iterator);
-
     return 0;
 }
+
 
 /**
  * @brief Return the final strengths of arguments of the Framework, NULL if an error occurred.
@@ -2330,6 +2483,9 @@ _QBAFramework_copy_settings(QBAFrameworkObject *self)
     copy->influence_function = self->influence_function;
     copy->min_strength = self->min_strength;
     copy->max_strength = self->max_strength;
+    copy->allow_cycles = self->allow_cycles;
+    copy->max_iterations = self->max_iterations;
+    copy->convergence_threshold = self->convergence_threshold;
 
     Py_XINCREF(self->aggregation_function_callable);
     copy->aggregation_function_callable = self->aggregation_function_callable;
@@ -2338,6 +2494,7 @@ _QBAFramework_copy_settings(QBAFrameworkObject *self)
     
     return (PyObject*)copy;
 }
+
 
 /**
  * @brief Return the reversal framework of self to other w.r.t. set, NULL if an error is encountered.
@@ -4402,6 +4559,30 @@ PyDoc_STRVAR(max_strength_doc,
 "Type: float\n"
 );
 
+PyDoc_STRVAR(allow_cycles_doc,
+"True if cyclic frameworks should be evaluated by synchronous iteration.\n"
+"\n"
+"Getter: Return whether cyclic frameworks are allowed.\n"
+"\n"
+"Type: bool\n"
+);
+
+PyDoc_STRVAR(max_iterations_doc,
+"The maximum number of synchronous iterations used for cyclic frameworks.\n"
+"\n"
+"Getter: Return the QBAFramework's maximum number of iterations.\n"
+"\n"
+"Type: int\n"
+);
+
+PyDoc_STRVAR(convergence_threshold_doc,
+"The convergence threshold used for cyclic frameworks.\n"
+"\n"
+"Getter: Return the QBAFramework's convergence threshold.\n"
+"\n"
+"Type: float\n"
+);
+
 /**
  * @brief A list with the setters and getters of the class QBAFramework
  * 
@@ -4425,6 +4606,12 @@ static PyGetSetDef QBAFramework_getsetters[] = {
      min_strength_doc, NULL},
     {"max_strength", (getter) QBAFramework_getmax_strength, NULL,
      max_strength_doc, NULL},
+    {"allow_cycles", (getter) QBAFramework_getallow_cycles, NULL,
+     allow_cycles_doc, NULL},
+    {"max_iterations", (getter) QBAFramework_getmax_iterations, NULL,
+     max_iterations_doc, NULL},
+    {"convergence_threshold", (getter) QBAFramework_getconvergence_threshold, NULL,
+     convergence_threshold_doc, NULL},
     {NULL}  /* Sentinel */
 };
 
@@ -4931,7 +5118,8 @@ PyDoc_STRVAR(QBAFramework_doc,
 "QBAFramework(arguments, initial_strengths, attack_relations, support_relations,\n"
 "    disjoint_relations=True, semantics=None,\n"
 "    aggregation_function=None, influence_function=None,\n"
-"    min_strength=-1.7976931348623157e+308, max_strength=1.7976931348623157e+308)\n"     
+"    min_strength=-1.7976931348623157e+308, max_strength=1.7976931348623157e+308,\n"
+"    allow_cycles=False, max_iterations=1000, convergence_threshold=1e-09)\n"
 "\n"
 "Args:\n"
 "    arguments (list): a list of QBAFArgument\n"
@@ -4950,6 +5138,9 @@ PyDoc_STRVAR(QBAFramework_doc,
 "        It can only be modified when the semantics are custom\n"
 "    max_strength (float, optional): The maximum value an initial strength can have. Defaults to 1.7976931348623157e+308.\n"
 "        It can only be modified when the semantics are custom\n"
+"    allow_cycles (bool, optional): True if cyclic frameworks should be evaluated by synchronous iteration. Defaults to False.\n"
+"    max_iterations (int, optional): Maximum number of synchronous iterations for cyclic frameworks. Defaults to 1000.\n"
+"    convergence_threshold (float, optional): Convergence threshold for cyclic frameworks. Defaults to 1e-09.\n"
 );
 
 /**

--- a/src/framework.c
+++ b/src/framework.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "structmember.h"
+#include <stdarg.h>
 #include <float.h>
 #include <string.h>
 
@@ -1690,9 +1691,290 @@ QBAFramework_isacyclic(QBAFrameworkObject *self, PyObject *Py_UNUSED(ignored))
     Py_RETURN_FALSE;
 }
 
+
+/**
+ * @brief Decrease the reference count of each given PyObject and return -1.0.
+ *
+ * @param number_of_objects the number of PyObject* arguments that follow
+ * @return double always -1.0
+ */
+static double
+_QBAFramework_decref_on_error(Py_ssize_t number_of_objects, ...)
+{
+    va_list objects_to_decref;
+    va_start(objects_to_decref, number_of_objects);
+
+    for (Py_ssize_t object_index = 0; object_index < number_of_objects; object_index++) {
+        PyObject *current_object = va_arg(objects_to_decref, PyObject *);
+        Py_XDECREF(current_object);
+    }
+
+    va_end(objects_to_decref);
+    return -1.0;
+}
+
+
+/**
+ * @brief Append argument to argument_stack.
+ *
+ * @param argument_stack a PyList used as a stack
+ * @param argument the argument to push
+ * @return int 0 if successful, -1 otherwise
+ */
+static int
+_QBAFramework_argument_stack_push(PyObject *argument_stack, PyObject *argument)
+{
+    return PyList_Append(argument_stack, argument);
+}
+
+
+/**
+ * @brief Remove the top item from argument_stack.
+ *
+ * @param argument_stack a PyList used as a stack
+ * @return int 0 if successful, -1 otherwise
+ */
+static int
+_QBAFramework_argument_stack_pop(PyObject *argument_stack)
+{
+    Py_ssize_t last_argument_index = PyList_GET_SIZE(argument_stack) - 1;
+    return PySequence_DelItem(argument_stack, last_argument_index);
+}
+
+
+/**
+ * @brief Return the top item from argument_stack.
+ *
+ * @param argument_stack a PyList used as a stack
+ * @return PyObject* borrowed reference to the top argument
+ */
+static PyObject *
+_QBAFramework_argument_stack_top(PyObject *argument_stack)
+{
+    Py_ssize_t last_argument_index = PyList_GET_SIZE(argument_stack) - 1;
+    return PyList_GET_ITEM(argument_stack, last_argument_index);
+}
+
+
+/**
+ * @brief Add any dependency of current_argument without a calculated final strength to argument_stack.
+ *
+ * @param self an instance of QBAFramework
+ * @param current_argument the argument whose dependencies are inspected
+ * @param argument_stack a PyList used as a stack
+ * @param arguments_on_stack a PySet with arguments currently on the stack
+ * @return int 0 if successful, -1 otherwise
+ */
+static int
+_QBAFramework_push_unresolved_dependencies(QBAFrameworkObject *self, PyObject *current_argument,
+                                           PyObject *argument_stack, PyObject *arguments_on_stack)
+{
+    PyObject *attackers = _QBAFARelations_agents((QBAFARelationsObject*)self->attack_relations, current_argument);
+    if (attackers == NULL) {
+        return -1;
+    }
+
+    PyObject *supporters = _QBAFARelations_agents((QBAFARelationsObject*)self->support_relations, current_argument);
+    if (supporters == NULL) {
+        Py_DECREF(attackers);
+        return -1;
+    }
+
+    PyObject *dependencies = PyList_Concat(attackers, supporters);
+    Py_DECREF(attackers);
+    Py_DECREF(supporters);
+    if (dependencies == NULL) {
+        return -1;
+    }
+
+    PyObject *dependency_iterator = PyObject_GetIter(dependencies);
+    PyObject *dependency_argument;
+    if (dependency_iterator == NULL) {
+        Py_DECREF(dependencies);
+        return -1;
+    }
+
+    while ((dependency_argument = PyIter_Next(dependency_iterator))) {
+        int dependency_has_calculated_strength = PyDict_Contains(self->final_strengths, dependency_argument);
+        if (dependency_has_calculated_strength < 0) {
+            Py_DECREF(dependency_argument);
+            Py_DECREF(dependency_iterator);
+            Py_DECREF(dependencies);
+            return -1;
+        }
+
+        if (!dependency_has_calculated_strength) {
+            int dependency_is_on_stack = PySet_Contains(arguments_on_stack, dependency_argument);
+            if (dependency_is_on_stack < 0) {
+                Py_DECREF(dependency_argument);
+                Py_DECREF(dependency_iterator);
+                Py_DECREF(dependencies);
+                return -1;
+            }
+            if (dependency_is_on_stack) {
+                Py_DECREF(dependency_argument);
+                Py_DECREF(dependency_iterator);
+                Py_DECREF(dependencies);
+                PyErr_SetString(PyExc_RuntimeError,
+                                "encountered a dependency cycle while calculating final strengths");
+                return -1;
+            }
+
+            if (_QBAFramework_argument_stack_push(argument_stack, dependency_argument) < 0) {
+                Py_DECREF(dependency_argument);
+                Py_DECREF(dependency_iterator);
+                Py_DECREF(dependencies);
+                return -1;
+            }
+        }
+
+        Py_DECREF(dependency_argument);
+    }
+
+    Py_DECREF(dependency_iterator);
+    Py_DECREF(dependencies);
+    return 0;
+}
+
+
+/**
+ * @brief Return the calculated final strengths of all arguments in arguments.
+ * Return NULL if any argument does not have a calculated final strength yet or if an error occurred.
+ *
+ * @param self an instance of QBAFramework
+ * @param arguments a list of QBAFArgument
+ * @return PyObject* a new PyList of PyFloat
+ */
+static PyObject *
+_QBAFramework_retrieve_computed_strengths(QBAFrameworkObject *self, PyObject *arguments)
+{
+    Py_ssize_t number_of_arguments = PyObject_Size(arguments);
+    if (number_of_arguments == -1) {
+        return NULL;
+    }
+
+    PyObject *calculated_strengths = PyList_New(number_of_arguments);
+    if (calculated_strengths == NULL) {
+        return NULL;
+    }
+
+    PyObject *argument_iterator = PyObject_GetIter(arguments);
+    PyObject *current_argument;
+    if (argument_iterator == NULL) {
+        Py_DECREF(calculated_strengths);
+        return NULL;
+    }
+
+    Py_ssize_t argument_index = 0;
+    while ((current_argument = PyIter_Next(argument_iterator))) {
+        int has_calculated_strength = PyDict_Contains(self->final_strengths, current_argument);
+        if (has_calculated_strength < 0) {
+            Py_DECREF(current_argument);
+            Py_DECREF(argument_iterator);
+            Py_DECREF(calculated_strengths);
+            return NULL;
+        }
+        if (!has_calculated_strength) {
+            Py_DECREF(current_argument);
+            Py_DECREF(argument_iterator);
+            Py_DECREF(calculated_strengths);
+            PyErr_SetString(PyExc_RuntimeError, "missing calculated final strength for dependency");
+            return NULL;
+        }
+
+        double current_strength = PyFloat_AsDouble(PyDict_GetItem(self->final_strengths, current_argument));
+        Py_DECREF(current_argument);
+        if (current_strength == -1.0 && PyErr_Occurred()) {
+            Py_DECREF(argument_iterator);
+            Py_DECREF(calculated_strengths);
+            return NULL;
+        }
+
+        PyObject *current_strength_object = PyFloat_FromDouble(current_strength);
+        if (current_strength_object == NULL) {
+            Py_DECREF(argument_iterator);
+            Py_DECREF(calculated_strengths);
+            return NULL;
+        }
+
+        PyList_SET_ITEM(calculated_strengths, argument_index, current_strength_object);
+        argument_index++;
+    }
+
+    Py_DECREF(argument_iterator);
+    return calculated_strengths;
+}
+
+
+/**
+ * @brief Calculate and store the final strength of current_argument from already-calculated dependencies.
+ *
+ * @param self an instance of QBAFramework
+ * @param current_argument the argument whose final strength is calculated
+ * @return int 0 if successful, -1 otherwise
+ */
+static int
+_QBAFramework_calculate_argument_with_resolved_dependencies(QBAFrameworkObject *self, PyObject *current_argument)
+{
+    PyObject *attackers = _QBAFARelations_agents((QBAFARelationsObject*)self->attack_relations, current_argument);
+    if (attackers == NULL) {
+        return -1;
+    }
+
+    PyObject *supporters = _QBAFARelations_agents((QBAFARelationsObject*)self->support_relations, current_argument);
+    if (supporters == NULL) {
+        Py_DECREF(attackers);
+        return -1;
+    }
+
+    PyObject *attacker_strengths = _QBAFramework_retrieve_computed_strengths(self, attackers);
+    if (attacker_strengths == NULL) {
+        Py_DECREF(attackers);
+        Py_DECREF(supporters);
+        return -1;
+    }
+
+    PyObject *supporter_strengths = _QBAFramework_retrieve_computed_strengths(self, supporters);
+    Py_DECREF(attackers);
+    Py_DECREF(supporters);
+    if (supporter_strengths == NULL) {
+        Py_DECREF(attacker_strengths);
+        return -1;
+    }
+
+    double aggregation = _QBAFramework_aggregation_function(self, attacker_strengths, supporter_strengths);
+    Py_DECREF(attacker_strengths);
+    Py_DECREF(supporter_strengths);
+    if (aggregation == -1.0 && PyErr_Occurred()) {
+        return -1;
+    }
+
+    double initial_strength = PyFloat_AsDouble(PyDict_GetItem(self->initial_strengths, current_argument));
+    if (initial_strength == -1.0 && PyErr_Occurred()) {
+        return -1;
+    }
+
+    double final_strength = _QBAFramework_influence_function(self, initial_strength, aggregation);
+    if (final_strength == -1.0 && PyErr_Occurred()) {
+        return -1;
+    }
+
+    PyObject *final_strength_object = PyFloat_FromDouble(final_strength);
+    if (final_strength_object == NULL) {
+        return -1;
+    }
+    if (PyDict_SetItem(self->final_strengths, current_argument, final_strength_object) < 0) {
+        Py_DECREF(final_strength_object);
+        return -1;
+    }
+    Py_DECREF(final_strength_object);
+    return 0;
+}
+
+
 /**
  * @brief Return the final strength of a specific argument, -1.0 if an error occurred.
- * This function calls itself recursively. So, it only works with acyclic arguments.
+ * This function evaluates dependencies iteratively. So, it only works with acyclic arguments.
  * It stores all the calculated final strengths in self.__final_strengths.
  * 
  * @param self an instance of QBAFramework
@@ -1702,7 +1984,6 @@ QBAFramework_isacyclic(QBAFrameworkObject *self, PyObject *Py_UNUSED(ignored))
 static double
 _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argument)
 {
-
     // Check if it has been calculated already
     int contains = PyDict_Contains(self->final_strengths, argument);
     if (contains < 0) {
@@ -1712,130 +1993,66 @@ _QBAFramework_calculate_final_strength(QBAFrameworkObject *self, PyObject *argum
         return PyFloat_AsDouble(PyDict_GetItem(self->final_strengths, argument));
     }
 
-    // Obtain final strength of attackers
-    PyObject *attackers = _QBAFARelations_agents((QBAFARelationsObject*)self->attack_relations, argument);
-    if (attackers == NULL) {
-        return -1.0;
+    PyObject *argument_stack = PyList_New(0);
+    PyObject *arguments_on_stack = PySet_New(NULL);
+    if (argument_stack == NULL || arguments_on_stack == NULL) {
+        return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
     }
 
-    PyObject *iterator = PyObject_GetIter(attackers);
-    if (iterator == NULL) {
-        Py_DECREF(attackers);
-        return -1.0;
-    }
-    Py_ssize_t size = PyObject_Size(attackers);
-    if (size == -1) {
-        Py_DECREF(attackers);
-        Py_DECREF(iterator);
-        return -1.0;
+    if (_QBAFramework_argument_stack_push(argument_stack, argument) < 0) {
+        return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
     }
 
-    PyObject *attacker_strengths = PyList_New(size);
-    if (attacker_strengths == NULL) {
-        Py_DECREF(attackers);
-        Py_DECREF(iterator);
-        return -1.0;
-    }
-    
-    PyObject *item;
-    Py_ssize_t index = 0;
-    while ((item = PyIter_Next(iterator))) { // PyIter_Next returns a new reference
-        double strength = _QBAFramework_calculate_final_strength(self, item);
-        Py_DECREF(item);
-        if (strength == -1.0 && PyErr_Occurred()) {
-            Py_DECREF(iterator);
-            Py_DECREF(attackers);
-            Py_DECREF(attacker_strengths);
-            return -1.0;
+    while (PyList_GET_SIZE(argument_stack) > 0) {
+        PyObject *current_argument = _QBAFramework_argument_stack_top(argument_stack);
+
+        contains = PyDict_Contains(self->final_strengths, current_argument);
+        if (contains < 0) {
+            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        }
+        if (contains) {
+            if (_QBAFramework_argument_stack_pop(argument_stack) < 0) {
+                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            }
+            if (PySet_Discard(arguments_on_stack, current_argument) < 0) {
+                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            }
+            continue;
         }
 
-        PyList_SET_ITEM(attacker_strengths, index, PyFloat_FromDouble(strength));
-
-        index++;
-    }
-
-    Py_DECREF(iterator);
-    Py_DECREF(attackers);
-
-    // Obtain final strength of supporters
-    PyObject *supporters = _QBAFARelations_agents((QBAFARelationsObject*)self->support_relations, argument);
-    if (supporters == NULL) {
-        Py_DECREF(attacker_strengths);
-        return -1.0;
-    }
-    iterator = PyObject_GetIter(supporters);
-
-    if (iterator == NULL) {
-        Py_DECREF(attacker_strengths);
-        Py_DECREF(supporters);
-        return -1.0;
-    }
-    size = PyObject_Size(supporters);
-    if (size == -1) {
-        Py_DECREF(attacker_strengths);
-        Py_DECREF(iterator);
-        Py_DECREF(supporters);
-        return -1.0;
-    }
-
-    PyObject *supporter_strengths = PyList_New(size);
-    if (supporter_strengths == NULL) {
-        Py_DECREF(attacker_strengths);
-        Py_DECREF(iterator);
-        Py_DECREF(supporters);
-        return -1.0;
-    }
-    
-    index = 0;
-    while ((item = PyIter_Next(iterator))) {    // PyIter_Next returns a new reference
-        double strength = _QBAFramework_calculate_final_strength(self, item);
-        Py_DECREF(item);
-        if (strength == -1.0 && PyErr_Occurred()) {
-            Py_DECREF(attacker_strengths);
-            Py_DECREF(iterator);
-            Py_DECREF(supporters);
-            Py_DECREF(supporter_strengths);
-            return -1.0;
+        int argument_is_on_stack = PySet_Contains(arguments_on_stack, current_argument);
+        if (argument_is_on_stack < 0) {
+            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
         }
 
-        PyList_SET_ITEM(supporter_strengths, index, PyFloat_FromDouble(strength));
+        // On first visit push dependencies. On second visit calculate final strength.
+        if (!argument_is_on_stack) {
+            if (PySet_Add(arguments_on_stack, current_argument) < 0) {
+                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            }
 
-        index++;
-    } 
+            if (_QBAFramework_push_unresolved_dependencies(self, current_argument, argument_stack, arguments_on_stack) < 0) {
+                return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+            }
+            continue;
+        }
 
-    Py_DECREF(iterator);
-    Py_DECREF(supporters);
-
-    // Obtain result from aggregation function
-    double aggregation = _QBAFramework_aggregation_function(self, attacker_strengths, supporter_strengths);
-    Py_DECREF(attacker_strengths);
-    Py_DECREF(supporter_strengths);
-    if (aggregation == -1.0 && PyErr_Occurred()) {
-        return -1.0;
+        if (_QBAFramework_calculate_argument_with_resolved_dependencies(self, current_argument) < 0) {
+            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        }
+        if (_QBAFramework_argument_stack_pop(argument_stack) < 0) {
+            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        }
+        if (PySet_Discard(arguments_on_stack, current_argument) < 0) {
+            return _QBAFramework_decref_on_error(2, argument_stack, arguments_on_stack);
+        }
     }
 
-    // Obtain initial strength
-    double initial_strength = PyFloat_AsDouble(PyDict_GetItem(self->initial_strengths, argument));
-    if (initial_strength == -1.0 && PyErr_Occurred()) {
-        return -1.0;
-    }
-
-    // calculate final strength;
-    double final_strength = _QBAFramework_influence_function(self, initial_strength, aggregation);
-    if (final_strength == -1.0 && PyErr_Occurred()) {
-        return -1.0;
-    }
-
-    // final_strengths[argument] = final_strength
-    PyObject *pyfinal_strength = PyFloat_FromDouble(final_strength);    // New reference
-    if (PyDict_SetItem(self->final_strengths, argument, pyfinal_strength) < 0) {
-        Py_XDECREF(pyfinal_strength);
-        return -1.0;
-    }
-    Py_XDECREF(pyfinal_strength);
-
-    return final_strength;
+    Py_DECREF(argument_stack);
+    Py_DECREF(arguments_on_stack);
+    return PyFloat_AsDouble(PyDict_GetItem(self->final_strengths, argument));
 }
+
 
 /**
  * @brief Calculate the final strengths of all the arguments of the Framework.

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -6,9 +6,9 @@ from qbaf_ctrbs.shapley import determine_shapley_ctrb
 
 
 def test_cyclic_framework_requires_allow_cycles():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     # QBAFramework defaults to allow_cycles=False
     framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model")
@@ -19,50 +19,50 @@ def test_cyclic_framework_requires_allow_cycles():
 
 
 def test_cyclic_framework_converges_when_cycles_are_allowed():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
     final_strengths = framework.final_strengths
     assert framework.isacyclic() is False
     assert framework.allow_cycles is True
-    assert final_strengths["A"] == pytest.approx(0.9999999990686774)
-    assert final_strengths["B"] == pytest.approx(0.0)
-    assert framework.final_strength("A") == pytest.approx(final_strengths["A"])
-    assert framework.final_strength("B") == pytest.approx(final_strengths["B"])
+    assert final_strengths['a'] == pytest.approx(0.9999999990686774)
+    assert final_strengths['b'] == pytest.approx(0.0)
+    assert framework.final_strength('a') == pytest.approx(final_strengths['a'])
+    assert framework.final_strength('b') == pytest.approx(final_strengths['b'])
 
 
 def test_cyclic_framework_recomputes_strengths_after_modification():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
     
     strengths_before_modification = framework.final_strengths
     
-    framework.modify_initial_strength("B", 0.8)
+    framework.modify_initial_strength('b', 0.8)
     strengths_after_modification = framework.final_strengths
     
-    assert strengths_before_modification["A"] == pytest.approx(0.9999999990686774)
-    assert strengths_before_modification["B"] == pytest.approx(0.0)
-    assert strengths_after_modification["A"] == pytest.approx(1.0)
-    assert strengths_after_modification["B"] == pytest.approx(0.0)
+    assert strengths_before_modification['a'] == pytest.approx(0.9999999990686774)
+    assert strengths_before_modification['b'] == pytest.approx(0.0)
+    assert strengths_after_modification['a'] == pytest.approx(1.0)
+    assert strengths_after_modification['b'] == pytest.approx(0.0)
     assert strengths_before_modification != strengths_after_modification
 
 
 def test_contribution_functions_work_for_cyclic_framework():
-    arguments = ["A", "B", "C"]
+    arguments = ['a', 'b', 'c']
     initial_strengths = [0.8, 0.4, 0.2]
-    attack_relations = [("A", "B"), ("B", "A")]
-    support_relations = [("C", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
+    support_relations = [('c', 'a')]
 
     framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
 
-    removal_contribution = determine_removal_ctrb("A", "C", framework)
-    shapley_contribution = determine_shapley_ctrb("A", "C", framework)
-    gradient_contribution = determine_gradient_ctrb("A", "C", framework)
+    removal_contribution = determine_removal_ctrb('a', 'c', framework)
+    shapley_contribution = determine_shapley_ctrb('a', 'c', framework)
+    gradient_contribution = determine_gradient_ctrb('a', 'c', framework)
 
     assert isinstance(removal_contribution, float)
     assert isinstance(shapley_contribution, float)
@@ -70,9 +70,9 @@ def test_contribution_functions_work_for_cyclic_framework():
 
 
 def test_non_converging_cyclic_framework_raises_runtime_error():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     framework = QBAFramework(arguments,
                              initial_strengths,
@@ -87,9 +87,9 @@ def test_non_converging_cyclic_framework_raises_runtime_error():
 
 
 def test_cycle_settings_are_exposed():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     framework = QBAFramework(arguments,
                              initial_strengths,
@@ -105,10 +105,10 @@ def test_cycle_settings_are_exposed():
 
 
 def test_allow_cycles_does_not_change_acyclic_framework_behavior():
-    arguments = ["A", "B", "C"]
+    arguments = ['a', 'b', 'c']
     initial_strengths = [2.0, 1.0, 1.0]
-    attack_relations = [("B", "A")]
-    support_relations = [("C", "B")]
+    attack_relations = [('b', 'a')]
+    support_relations = [('c', 'b')]
     # The graph has no cycles but we test with allow_cycles=True
     framework = QBAFramework(arguments,
                              initial_strengths,
@@ -117,13 +117,13 @@ def test_allow_cycles_does_not_change_acyclic_framework_behavior():
                              semantics="basic_model",
                              allow_cycles=True,)
     assert framework.isacyclic() is True
-    assert framework.final_strengths == {"A": 0.0, "B": 2.0, "C": 1.0}
+    assert framework.final_strengths == {'a': 0.0, 'b': 2.0, 'c': 1.0}
 
 
 def test_reversal_preserves_cycle_settings():
-    arguments = ["A", "B"]
+    arguments = ['a', 'b']
     initial_strengths = [1.0, 0.5]
-    attack_relations = [("A", "B"), ("B", "A")]
+    attack_relations = [('a', 'b'), ('b', 'a')]
     support_relations = []
     framework = QBAFramework(arguments,
                              initial_strengths,
@@ -138,5 +138,5 @@ def test_reversal_preserves_cycle_settings():
     assert reversal.allow_cycles is True
     assert reversal.max_iterations == 850
     assert reversal.convergence_threshold == pytest.approx(1e-5)
-    assert reversal.final_strengths["A"] == pytest.approx(framework.final_strengths["A"])
-    assert reversal.final_strengths["B"] == pytest.approx(framework.final_strengths["B"])
+    assert reversal.final_strengths['a'] == pytest.approx(framework.final_strengths['a'])
+    assert reversal.final_strengths['b'] == pytest.approx(framework.final_strengths['b'])

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -1,0 +1,142 @@
+import pytest
+from qbaf import QBAFramework
+from qbaf_ctrbs.gradient import determine_gradient_ctrb
+from qbaf_ctrbs.removal import determine_removal_ctrb
+from qbaf_ctrbs.shapley import determine_shapley_ctrb
+
+
+def test_cyclic_framework_requires_allow_cycles():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    # QBAFramework defaults to allow_cycles=False
+    framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model")
+
+    assert framework.isacyclic() is False
+    with pytest.raises(NotImplementedError):
+        _ = framework.final_strengths
+
+
+def test_cyclic_framework_converges_when_cycles_are_allowed():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
+    final_strengths = framework.final_strengths
+    assert framework.isacyclic() is False
+    assert framework.allow_cycles is True
+    assert final_strengths["A"] == pytest.approx(0.9999999990686774)
+    assert final_strengths["B"] == pytest.approx(0.0)
+    assert framework.final_strength("A") == pytest.approx(final_strengths["A"])
+    assert framework.final_strength("B") == pytest.approx(final_strengths["B"])
+
+
+def test_cyclic_framework_recomputes_strengths_after_modification():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
+    
+    strengths_before_modification = framework.final_strengths
+    
+    framework.modify_initial_strength("B", 0.8)
+    strengths_after_modification = framework.final_strengths
+    
+    assert strengths_before_modification["A"] == pytest.approx(0.9999999990686774)
+    assert strengths_before_modification["B"] == pytest.approx(0.0)
+    assert strengths_after_modification["A"] == pytest.approx(1.0)
+    assert strengths_after_modification["B"] == pytest.approx(0.0)
+    assert strengths_before_modification != strengths_after_modification
+
+
+def test_contribution_functions_work_for_cyclic_framework():
+    arguments = ["A", "B", "C"]
+    initial_strengths = [0.8, 0.4, 0.2]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = [("C", "A")]
+
+    framework = QBAFramework(arguments, initial_strengths, attack_relations, support_relations, semantics="DFQuAD_model", allow_cycles=True)
+
+    removal_contribution = determine_removal_ctrb("A", "C", framework)
+    shapley_contribution = determine_shapley_ctrb("A", "C", framework)
+    gradient_contribution = determine_gradient_ctrb("A", "C", framework)
+
+    assert isinstance(removal_contribution, float)
+    assert isinstance(shapley_contribution, float)
+    assert isinstance(gradient_contribution, float)
+
+
+def test_non_converging_cyclic_framework_raises_runtime_error():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    framework = QBAFramework(arguments,
+                             initial_strengths,
+                             attack_relations,
+                             support_relations,
+                             semantics="basic_model",
+                             allow_cycles=True,
+                             max_iterations=1000,
+                             convergence_threshold=1e-9,)
+    with pytest.raises(RuntimeError, match="did not converge"):
+        _ = framework.final_strengths
+
+
+def test_cycle_settings_are_exposed():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    framework = QBAFramework(arguments,
+                             initial_strengths,
+                             attack_relations,
+                             support_relations,
+                             semantics="DFQuAD_model",
+                             allow_cycles=True,
+                             max_iterations=17,
+                             convergence_threshold=1e-5,)
+    assert framework.allow_cycles is True
+    assert framework.max_iterations == 17
+    assert framework.convergence_threshold == pytest.approx(1e-5)
+
+
+def test_allow_cycles_does_not_change_acyclic_framework_behavior():
+    arguments = ["A", "B", "C"]
+    initial_strengths = [2.0, 1.0, 1.0]
+    attack_relations = [("B", "A")]
+    support_relations = [("C", "B")]
+    # The graph has no cycles but we test with allow_cycles=True
+    framework = QBAFramework(arguments,
+                             initial_strengths,
+                             attack_relations,
+                             support_relations,
+                             semantics="basic_model",
+                             allow_cycles=True,)
+    assert framework.isacyclic() is True
+    assert framework.final_strengths == {"A": 0.0, "B": 2.0, "C": 1.0}
+
+
+def test_reversal_preserves_cycle_settings():
+    arguments = ["A", "B"]
+    initial_strengths = [1.0, 0.5]
+    attack_relations = [("A", "B"), ("B", "A")]
+    support_relations = []
+    framework = QBAFramework(arguments,
+                             initial_strengths,
+                             attack_relations,
+                             support_relations,
+                             semantics="DFQuAD_model",
+                             allow_cycles=True,
+                             max_iterations=850,
+                             convergence_threshold=1e-5,)
+
+    reversal = framework.reversal(framework, [])
+    assert reversal.allow_cycles is True
+    assert reversal.max_iterations == 850
+    assert reversal.convergence_threshold == pytest.approx(1e-5)
+    assert reversal.final_strengths["A"] == pytest.approx(framework.final_strengths["A"])
+    assert reversal.final_strengths["B"] == pytest.approx(framework.final_strengths["B"])

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -140,3 +140,28 @@ def test_reversal_preserves_cycle_settings():
     assert reversal.convergence_threshold == pytest.approx(1e-5)
     assert reversal.final_strengths['a'] == pytest.approx(framework.final_strengths['a'])
     assert reversal.final_strengths['b'] == pytest.approx(framework.final_strengths['b'])
+
+
+def test_four_node_attack_cycle():
+    arguments = ['a', 'b', 'c', 'd']
+    initial_strengths = [0.1, 0.1, 0.1, 0.1]
+    attack_relations = [('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'a')]
+    support_relations = []
+
+    framework = QBAFramework(arguments,
+                             initial_strengths,
+                             attack_relations,
+                             support_relations,
+                             semantics="DFQuAD_model",
+                             allow_cycles=True)
+
+    final_strengths = framework.final_strengths
+    assert framework.isacyclic() is False
+    assert set(final_strengths.keys()) == set(arguments)
+    for argument in arguments:
+        assert framework.final_strength(argument) == pytest.approx(final_strengths[argument])
+        assert 0.0 <= final_strengths[argument] < 0.1
+    values = [final_strengths[arg] for arg in arguments]
+    assert values[0] == pytest.approx(values[1])
+    assert values[1] == pytest.approx(values[2])
+    assert values[2] == pytest.approx(values[3])


### PR DESCRIPTION
## Summary
This PR adds support for cyclic QBAFs by introducing synchronous iterative strength evaluation when `allow_cycles=True` (default it False).


## Changes

- Added cyclic final-strength evaluation in the C core.
- Kept the existing acyclic evaluation path (more or less) intact (old test still pass).
- Exposed cycle configuration through the Python API:
    - `allow_cycles`,
    - `max_iterations`,
    - `convergence_threshold`.
- Preserved cycle settings in derived/reversal frameworks
- Added dedicated cycle tests, including:
    - cyclic evaluation disabled by default,
    - converging cyclic evaluation,
    - non-converging cyclic evaluation,
    - reversal preserving cycle settings.

 ## Notes

- Cyclic evaluation uses synchronous updates from the previous iteration (starts with initial strength).
- Cyclic frameworks still raise if `allow_cycles=False`.
- Cyclic evaluation raises `RuntimeError` if convergence is not reached within `max_iterations`.
- Defaults: `allow_cycles=False`, `max_iterations=1000`, and `convergence_threshold=1e-9`


## Flow
The code now does this:

 - `framework.final_strengths`
    - `QBAFramework_getfinal_strengths`
      - `_QBAFRamework_calculate_final_strengths`
        - if the framework is acyclic
          - for each argument
            - `_QBAFramework_calculate_final_strength`
              - if the argument has unresolved dependencies: 
              - `_QBAFramework_push_unresolved_dependencies`
              - if the argument's dependencies are resolved: 
              - `_QBAFramework_apply_semantics`
        - if the framework is cyclic and `allow_cycles=True`
          - `_QBAFramework_calculate_cyclic_final_strengths`
            - repeat
              - `_QBAFramework_calculate_next_strengths`
                - for each argument: 
                - `_QBAFramework_apply_semantics`
              - Check if: `_QBAFramework_strengths_have_converged`


## Things to think about before merging
- Should we store each intermediate step (if history=True or something similar)? This would allow easier plotting but more mem.
- Should cyclic evaluation remain opt-in via `allow_cycles=False` by default, or should cyclic frameworks evaluate automatically?
- What should the public behavior be when a cyclic framework does not converge?
      - Raise RuntimeError.
      - Return the last approximation.
      - Expose both.
